### PR TITLE
FEAT: 쿠키 파싱 및 JWT 인증 미들웨어 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "ISC",
 			"dependencies": {
 				"bcrypt": "^5.1.1",
+				"cookie-parser": "^1.4.7",
 				"cors": "^2.8.5",
 				"dotenv": "^16.4.5",
 				"express": "^4.21.1",
@@ -21,6 +22,7 @@
 			},
 			"devDependencies": {
 				"@types/bcrypt": "^5.0.2",
+				"@types/cookie-parser": "^1.4.7",
 				"@types/cors": "^2.8.17",
 				"@types/express": "^5.0.0",
 				"@types/hpp": "^0.2.6",
@@ -442,6 +444,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/cookie-parser": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.7.tgz",
+			"integrity": "sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express": "*"
 			}
 		},
 		"node_modules/@types/cors": {
@@ -1271,6 +1283,28 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
 			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-parser": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+			"integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+			"license": "MIT",
+			"dependencies": {
+				"cookie": "0.7.2",
+				"cookie-signature": "1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/cookie-parser/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"license": "ISC",
 	"dependencies": {
 		"bcrypt": "^5.1.1",
+		"cookie-parser": "^1.4.7",
 		"cors": "^2.8.5",
 		"dotenv": "^16.4.5",
 		"express": "^4.21.1",
@@ -25,6 +26,7 @@
 	},
 	"devDependencies": {
 		"@types/bcrypt": "^5.0.2",
+		"@types/cookie-parser": "^1.4.7",
 		"@types/cors": "^2.8.17",
 		"@types/express": "^5.0.0",
 		"@types/hpp": "^0.2.6",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import cookieParser from 'cookie-parser';
 import helmet from 'helmet';
 import hpp from 'hpp';
 import cors from 'cors';
@@ -26,6 +27,7 @@ App.use(
 );
 
 App.use(express.json());
+App.use(cookieParser());
 
 const insertDummyData = async () => {
 	try {

--- a/src/middlewares/authHandler.ts
+++ b/src/middlewares/authHandler.ts
@@ -1,0 +1,69 @@
+import { AppError, sendCookie } from '@/utils';
+import {
+	generateAccessToken,
+	generateRefreshToken,
+	verifyAccessToken,
+	verifyRefreshToken,
+} from '@/utils/jwt';
+import { NextFunction, Request, Response } from 'express';
+
+const authHandler = async (req: Request, res: Response, next: NextFunction) => {
+	try {
+		const accessToken = req.cookies.accessToken;
+
+		if (!accessToken) {
+			// 1. 액세스 토큰이 없는경우, 리프레시 토큰 확인
+			return refreshTokenHandler(req, res, next);
+		}
+
+		// 2. 액세스 토큰 검증
+		try {
+			verifyAccessToken(accessToken);
+
+			return next();
+		} catch (e) {
+			// 3. 액세스 토큰이 만료된 경우, 리프레시 토큰 확인
+			if (e instanceof AppError && e.statusCode === 403) {
+				return refreshTokenHandler(req, res, next);
+			}
+
+			return next(e);
+		}
+	} catch (e) {
+		next(e);
+	}
+};
+
+const refreshTokenHandler = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => {
+	try {
+		const refreshToken = req.cookies.refreshToken;
+
+		if (!refreshToken) {
+			throw new AppError(
+				'유효한 인증 토큰이 없습니다. 잘못된 접근입니다.',
+				401,
+			);
+		}
+
+		// 1. 리프레시 토큰 검증
+		const decoded = verifyRefreshToken(refreshToken) as { id: string };
+
+		// 2. 새로운 토큰 발급
+		const newAccessToken = generateAccessToken({ id: decoded.id });
+		const newRefreshToken = generateRefreshToken({ id: decoded.id });
+
+		// 3. 새로운 토큰을 쿠키에 설정
+		sendCookie(res, 'accessToken', newAccessToken, 1);
+		sendCookie(res, 'refreshToken', newRefreshToken, 24);
+
+		next();
+	} catch (e) {
+		next(e);
+	}
+};
+
+export default authHandler;

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,2 +1,3 @@
 export { default as errorHandler } from './errorHandler';
 export { default as notFoundHandler } from './notFoundHandler';
+export { default as authHandler } from './authHandler';

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -33,7 +33,12 @@ export const verifyAccessToken = (token: string) => {
 	try {
 		return jwt.verify(token, JWT_ACCESS_SECRET as string);
 	} catch (e) {
-		throw new AppError('유효하지 않은 Refresh Token입니다.', 403);
+		if (e instanceof jwt.TokenExpiredError)
+			throw new AppError('만료된 accessToken 입니다.', 403);
+		else if (e instanceof jwt.JsonWebTokenError)
+			throw new AppError('유효하지 않은 accessToken 입니다.', 401);
+		else
+			throw new AppError('토큰 검증 중 알 수 없는 오류가 발생했습니다.', 500);
 	}
 };
 
@@ -44,6 +49,11 @@ export const verifyRefreshToken = (token: string) => {
 	try {
 		return jwt.verify(token, JWT_REFRESH_SECRET as string);
 	} catch (e) {
-		throw new AppError('유효하지 않은 Refresh Token입니다.', 403);
+		if (e instanceof jwt.TokenExpiredError)
+			throw new AppError('만료된 refreshToken 입니다.', 403);
+		else if (e instanceof jwt.JsonWebTokenError)
+			throw new AppError('유효하지 않은 refreshToken 입니다.', 401);
+		else
+			throw new AppError('토큰 검증 중 알 수 없는 오류가 발생했습니다.', 500);
 	}
 };


### PR DESCRIPTION
# 주요 변경 사항
1. **Chore: `cookie-parser` 설치**
  - 쿠키 사용을 위해 라이브러리 설치.
2. **Chore: `cookie-parser` 미들웨어 추가**
  - `cookie-parser` 미들웨어 사용을 위해 배치.
3. **Refactor: JWT 인증 에러 처리 세분화**
  - 액세스 토큰과 리프레시 토큰 처리를 원활히 하기 위해 에러를 좀더 구체적으로 구분.
4. **Feat: 사용자 인증 미들웨어 (authHandler) 구현**
  - JWT 액세스 토큰과 리프레시 토큰 검증 및 재발급 로직 구현.
  (간이 테스트 완료, 추후 다른 기능 개발 완료되면 배치 예정)